### PR TITLE
fix: change main and types to index

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Once you have imported both modules, Set This SDK [Axios](https://axios-http.com
 const config = new Configuration({
   apiKey: process.env.TILLED_SECRET_KEY,
   basePath: 'https://sandbox-api.tilled.com', // defaults to https://api.tilled.com
-  baseOptions: { timeout: 2000 } // overide default settings with an Axios config
+  baseOptions: { timeout: 2000 } // override default settings with an Axios config
 });
 ```
 
@@ -59,7 +59,7 @@ const paymentIntentsApi = new PaymentIntentsApi(config);
 
 ### Creating a Payment Intent
 
-We are now ready to make a payment. First, we need to [create a payment intent](https://docs.tilled.com/api#tag/PaymentIntents/operation/CreatePaymentIntent). This should be done as soon as your checkout page or componet is loaded. You can set up the endpoint for your frontend like so:
+We are now ready to make a payment. First, we need to [create a payment intent](https://docs.tilled.com/api#tag/PaymentIntents/operation/CreatePaymentIntent). This should be done as soon as your checkout page or component is loaded. You can set up the endpoint for your frontend like so:
 
 ```typescript
 app.post(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tilled-node",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tilled-node",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "Unlicense",
       "dependencies": {
         "axios": "^0.27.2"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "type": "git",
     "url": "https://github.com/gettilled/tilled-node.git"
   },
-  "main": "dist/api.js",
-  "types": "dist/api.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "prettier:check": "npx prettier --config .prettierrc --check .",
     "prettier:write": "npx prettier --config .prettierrc --write .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilled-node",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "NodeJS SDK client for Tilled's API",
   "files": [
     "dist"


### PR DESCRIPTION
I just updated our React Example to use 0.0.3 and everything is working. However, the module path needs `/dist` to work correctly.

![image (25)](https://user-images.githubusercontent.com/65815343/235948317-9ed3ba47-7d3a-4a42-bbf1-741f1f90bb2c.png)

This PR fixes this by updating the `main` and `types` properties in the package.json to `dist/index.js` and `dist/index.d.ts` respectively.

Using `api.js` and `api.d.ts` gives us access to the apis, but not the Configuration, Request and Params models.
