### PR TITLE
updating workflow for slack notifications

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
         run: npm run generate
 
       - name: Publish NPM Package
+        id: publish
         uses: JS-DevTools/npm-publish@v2
         with:
           token: ${{ secrets.NPM_TOKEN }}
@@ -73,3 +74,13 @@ jobs:
         if: always()
         id: deployment
         uses: actions/deploy-pages@v2
+
+      - name: Notify in Slack sdk-builds channel if new changes are published
+        if: ${{ steps.publish.outputs.type }}
+        uses: 8398a7/action-slack@v3
+        with:
+          text: '${{ steps.publish.outputs.id }} has been published. See the latest here https://www.npmjs.com/package/tilled-node'
+          status: ${{ job.status }}
+          fields: workflow
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SDK }}


### PR DESCRIPTION
This will update the github action to notify us via slack if the version has changed and npm package is published. By Default the npm package will only get pushed to npm and updated if the version changes in the package.json file via the versioning command found in contributing before pushing code.

## Versioning

```bash
npm version patch // 1.0.1
npm version minor // 1.1.0
npm version major // 2.0.0
```