### PR TITLE
Fix/add-basepath-to-config

### DIFF
--- a/configuration.ts
+++ b/configuration.ts
@@ -96,6 +96,7 @@ export class Configuration {
     this.username = param.username;
     this.password = param.password;
     this.accessToken = param.accessToken;
+    this.basePath = param.basePath;
     this.baseOptions = {
       ...param.baseOptions,
       headers: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tilled-node",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tilled-node",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "Unlicense",
       "dependencies": {
         "axios": "^0.27.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilled-node",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "NodeJS SDK client for Tilled's API",
   "files": [
     "dist"


### PR DESCRIPTION
in my recent changes to configuration.ts, I deleted the statement to set the basePath in the axios config to the provided basePath. 

I meant to replace the old baseOptions assignment (line 107 that Tyler pointed out), but I must have fat fingered it and replaced the basePath instead. 

This fix restores the ability to specify the basePath and has been tested locally