### PR TITLE
Fix/use strict

### DIFF
--- a/model/card-charge-fee-template.ts
+++ b/model/card-charge-fee-template.ts
@@ -59,6 +59,12 @@ export interface CardChargeFeeTemplate {
      * @memberof CardChargeFeeTemplate
      */
     'transaction_fee_type': CardChargeFeeTemplateTransactionFeeType;
+    /**
+     * The amount of the fee applied per card updated, in currency minor units.
+     * @type {number}
+     * @memberof CardChargeFeeTemplate
+     */
+    'card_update_fee'?: number;
 }
 
 export const CardChargeFeeTemplateTransactionFeeType = {

--- a/model/user-email-settings-update-params.ts
+++ b/model/user-email-settings-update-params.ts
@@ -31,7 +31,7 @@ export interface UserEmailSettingsUpdateParams {
 export const UserEmailSettingsUpdateParamsDisputes = {
     TRUE: true,
     FALSE: false,
-    NULL: null as any
+    NULL: null
 } as const;
 
 export type UserEmailSettingsUpdateParamsDisputes = typeof UserEmailSettingsUpdateParamsDisputes[keyof typeof UserEmailSettingsUpdateParamsDisputes];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tilled-node",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tilled-node",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "Unlicense",
       "dependencies": {
         "axios": "^0.27.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilled-node",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "NodeJS SDK client for Tilled's API",
   "files": [
     "dist"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
+    "strict": true,
     "declaration": true,
     "target": "ES5",
     "module": "commonjs",
-    "noImplicitAny": false,
     "outDir": "dist",
     "rootDir": ".",
     "lib": ["es6", "dom"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "target": "ES5",
     "module": "commonjs",
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "outDir": "dist",
     "rootDir": ".",
     "lib": ["es6", "dom"],


### PR DESCRIPTION
This PR updates the project tsconfig to use strict the strict property to resolve implicit  `any` errors on null values. 

Why:
Build failed on last PR due to [a property's type being implicitly set to any](https://github.com/gettilled/tilled-node/actions/runs/5772529268/job/15647609876). This error is in the generated code ([UserEmailSettingsUpdateParamsDisputes](https://github.com/gettilled/tilled-node/blob/90e130d94b030245bdd32c34951a1fceff435ff3/model/user-email-settings-update-params.ts#L31-L36)). I set `strict: true` on the tsconfig which effectively adds strictNullChecks in addition to noImplicitAny to give null and undefined their own types to resolve the error