### PR TITLE
chore: patch version on schedule or workflow dispatch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,9 @@ jobs:
       - run: npm ci --ignore-scripts
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
+      - run: npm version patch
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+
       - name: Build package and generate docs
         run: npm run generate
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
 
       - run: npm version patch
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/main' }}
 
       - name: Build package and generate docs
         run: npm run generate

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tilled-node",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tilled-node",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "license": "Unlicense",
       "dependencies": {
         "axios": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilled-node",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "NodeJS SDK client for Tilled's API",
   "files": [
     "dist"


### PR DESCRIPTION
[Workflow](https://github.com/gettilled/tilled-node/actions/runs/8342591618) was completed successfully, but the package was not published due to the lack of a version bump. I added a conditional step to patch the version if the workflow is triggered by the cron job and the ref is on main:
```
- run: npm version patch
  if: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/main' }}
```