### PR TITLE
chore: commit changes back to repo in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,14 +98,15 @@ jobs:
         if: always()
         id: deployment
         uses: actions/deploy-pages@v2
+        
 
       - name: Commit Changes
-        run: |
-          new_version=$(npm show tilled-node version)
-          git add .
-          git diff --quiet && git diff --staged --quiet || git commit -m "Auto-update: $new_version" && git push
-        if: always()
-
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          file_pattern: package.json version.ts
+          commit_message: 'Auto-update: ${{ steps.publish.outputs.id }}'
+          commit_user_name: svc-gh-actions
+          
       - name: Notify in Slack sdk-builds channel if new changes are published
         if: ${{ steps.publish.outputs.type }}
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,6 +99,13 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v2
 
+      - name: Commit Changes
+        run: |
+          new_version=$(npm show tilled-node version)
+          git add .
+          git diff --quiet && git diff --staged --quiet || git commit -m "Auto-update: $new_version" && git push
+        if: always()
+
       - name: Notify in Slack sdk-builds channel if new changes are published
         if: ${{ steps.publish.outputs.type }}
         uses: 8398a7/action-slack@v3


### PR DESCRIPTION
CI ran successfully, but it seems like we need to commit the changes to the repo (i.e. the bumped package version) after the workflow finishes. Currently, the version number in Github is still 0.0.18, so when the job ran, it bumped it to 0.0.19. Because of that, all the publishing steps got skipped… again.