### PR TITLE
Dp/fix-commit-logic-in-ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,6 +101,7 @@ jobs:
         
 
       - name: Commit Changes
+        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           file_pattern: package.json version.ts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,6 +106,7 @@ jobs:
           file_pattern: package.json version.ts
           commit_message: 'Auto-update: ${{ steps.publish.outputs.id }}'
           commit_user_name: svc-gh-actions
+          skip_dirty_check: true # Working tree will likely be clean after version bump
           
       - name: Notify in Slack sdk-builds channel if new changes are published
         if: ${{ steps.publish.outputs.type }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tilled-node",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tilled-node",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "license": "Unlicense",
       "dependencies": {
         "axios": "^1.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tilled-node",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tilled-node",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "license": "Unlicense",
       "dependencies": {
         "axios": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilled-node",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "NodeJS SDK client for Tilled's API",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilled-node",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "NodeJS SDK client for Tilled's API",
   "files": [
     "dist"


### PR DESCRIPTION
CI ended up not updating the repo because the working tree is technically clean after running `npm version patch` since that command automatically creates a commit. 

To fix, this PR sets `skip_dirty_check: true` to create a commit anyway even if the working tree is clean.