### PR TITLE
chore: commit changes last

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,16 +98,6 @@ jobs:
         if: always()
         id: deployment
         uses: actions/deploy-pages@v2
-        
-
-      - name: Commit Changes
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          file_pattern: package.json version.ts
-          commit_message: 'Auto-update: ${{ steps.publish.outputs.id }}'
-          commit_user_name: svc-gh-actions
-          skip_dirty_check: true # Working tree will likely be clean after version bump
           
       - name: Notify in Slack sdk-builds channel if new changes are published
         if: ${{ steps.publish.outputs.type }}
@@ -118,3 +108,12 @@ jobs:
           fields: workflow
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SDK }}
+          
+      - name: Commit Changes
+        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          file_pattern: package.json
+          commit_message: 'Auto-update: ${{ steps.publish.outputs.id }}'
+          commit_user_name: svc-gh-actions
+          skip_dirty_check: true # Working tree will likely be clean after version bump

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tilled-node",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tilled-node",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "license": "Unlicense",
       "dependencies": {
         "axios": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilled-node",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "NodeJS SDK client for Tilled's API",
   "files": [
     "dist"


### PR DESCRIPTION
Last CI run [failed](https://github.com/gettilled/tilled-node/actions/runs/8615310214/job/23610573286) to commit the bumped version back to version control:
```
fatal: pathspec 'version.ts' did not match any files
```
I also moved the commit changes step to the end of the action since a failure of this kind means we don't get notified via `#sdk-build` if that step fails, even if the publish steps are completed successfully. 