### PR TITLE
fix: use push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,11 +109,6 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SDK }}
           
-      - name: Commit Changes
+      - name: Push Changes
         if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          file_pattern: package.json
-          commit_message: 'Auto-update: ${{ steps.publish.outputs.id }}'
-          commit_user_name: svc-gh-actions
-          skip_dirty_check: true # Working tree will likely be clean after version bump
+        run: git push --follow-tags


### PR DESCRIPTION
We are still running into issues with the version change commit on the checked out branch in CI getting commited back to the origin. 

I know @bmayhew brought up concerns with this approach, but I would like to try it before mirroring the versioning system we use in hawkeye. If this works, it will be a lot simpler since `npm version patch` already bumps the version and the Git tags rather than maintaining a separate `version.ts` to handle it.