### PR TITLE
chore: update test to reflect changes in how chome logs payment methods to the console

### DIFF
--- a/model/account.ts
+++ b/model/account.ts
@@ -133,7 +133,8 @@ export interface Account {
 
 export const AccountType = {
     PARTNER: 'partner',
-    MERCHANT: 'merchant'
+    MERCHANT: 'merchant',
+    RESELLER: 'reseller'
 } as const;
 
 export type AccountType = typeof AccountType[keyof typeof AccountType];

--- a/model/model-file.ts
+++ b/model/model-file.ts
@@ -97,7 +97,8 @@ export const ModelFileType = {
     JPG: 'jpg',
     PDF: 'pdf',
     CSV: 'csv',
-    TIFF: 'tiff'
+    TIFF: 'tiff',
+    ICO: 'ico'
 } as const;
 
 export type ModelFileType = typeof ModelFileType[keyof typeof ModelFileType];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tilled-node",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tilled-node",
-      "version": "0.0.30",
+      "version": "0.0.31",
       "license": "Unlicense",
       "dependencies": {
         "axios": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilled-node",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "NodeJS SDK client for Tilled's API",
   "files": [
     "dist"

--- a/test/make-payment.spec.ts
+++ b/test/make-payment.spec.ts
@@ -78,12 +78,15 @@ test('create and confirm a payment intent with a new card payment method', async
   // expect console.log to show the payment intent status
   // this confirms that we were able to successfully confirm the payment intent
   expect(consoleMsgArr.join('\n')).toMatch(
-    generateRegexFromArray([
-      'creating new pm card {name: Testy McTesterson, address: Object}',
-      'new pm {ach_debit: null, billing_details: Object, card: Object, card_present: null, chargeable: true}',
-      'attaching pm to customer {ach_debit: null, billing_details: Object, card: Object, card_present: null, chargeable: true}',
-      'using saved pm {ach_debit: null, billing_details: Object, card: Object, card_present: null, chargeable: true}'
-    ])
+    generateRegexFromArray(
+      [
+        'creating new pm card {name: Testy McTesterson, address: Object}',
+        'new pm {ach_debit: null, billing_details: Object, card_present: null, chargeable: true, created_at:',
+        'attaching pm to customer {ach_debit: null, billing_details: Object, card_present: null, chargeable: true, created_at:',
+        'using saved pm {ach_debit: null, billing_details: Object, card_present: null, chargeable: true, created_at:'
+      ],
+      DelimiterEnum.wildcards
+    )
   );
 });
 


### PR DESCRIPTION
This PR addresses this [failed GHA](https://github.com/gettilled/tilled-node/actions/runs/9956395024). The SDK is working fine, but the Chome console changed how it logs the payment method object. It now includes `created_at`, which I cannot access from the test. I will make a ticket to refactor this test in the future, but for now I will use wildcards to omit the `created_at` date