### PR TITLE
chore: remove beta disclaimer from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # tilled-node
 
-## Disclaimer
-
-This project is still in beta. It is generated and regenerated regularly when we make changes to our spec, but we cannot guarantee it's reliability at this time.
-
 ---
 
 ## Description

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tilled-node",
-  "version": "0.0.45",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tilled-node",
-      "version": "0.0.45",
+      "version": "1.0.0",
       "license": "Unlicense",
       "dependencies": {
         "axios": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilled-node",
-  "version": "0.0.45",
+  "version": "1.0.0",
   "description": "NodeJS SDK client for Tilled's API",
   "files": [
     "dist"


### PR DESCRIPTION
This repository has met the criteria for moving out of beta for a while. It has automated testing and regular deployments. We have monitoring for new issues. It's being used in 250k production requests per week.

Should we do a major version release to 1.0.0?