### PR TITLE
chore: create new customer and set the id as an env variable

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,8 +15,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-      - name: Build the package
-        run: npm run build
       - name: Create .env files in submodule
         run: node test/ci-setup-env.js
         env:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,6 +15,8 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: 18
+    - name: Build the package
+      run: npm run build
     - name: Create .env files in submodule
       run: node test/ci-setup-env.js
       env: 

--- a/test/ci-setup-env.js
+++ b/test/ci-setup-env.js
@@ -26,7 +26,7 @@ function createNewCustomer() {
       })
       .then((data) => {
           console.log(data);
-        var customerId = process.env.VITE_TILLED_CUSTOMER_ID || data.id;
+        var customerId = data.id || process.env.VITE_TILLED_CUSTOMER_ID;
   
         var serverEnv =
           'BASE_PATH=https://staging-api.tilled.com\nTILLED_SECRET_KEY='

--- a/test/ci-setup-env.js
+++ b/test/ci-setup-env.js
@@ -1,24 +1,80 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-var fs = require("fs");
-var serverEnv = "BASE_PATH=https://staging-api.tilled.com\nTILLED_SECRET_KEY=".concat(process.env.TILLED_SECRET_KEY, "\nTILLED_PARTNER_ACCOUNT=").concat(process.env.TILLED_PARTNER_ACCOUNT);
-var clientEnv = "VITE_TILLED_PUBLIC_KEY=".concat(process.env.VITE_TILLED_PUBLIC_KEY, "\nVITE_TILLED_MERCHANT_ACCOUNT_ID=").concat(process.env.VITE_TILLED_MERCHANT_ACCOUNT_ID, "\nVITE_TILLED_CUSTOMER_ID=").concat(process.env.VITE_TILLED_CUSTOMER_ID, "\nVITE_TILLED_MERCHANT_NAME=SDK Test\nVITE_TILLED_MERCHANT_TAX=1");
-var envVarsExist = process.env.TILLED_SECRET_KEY && process.env.TILLED_PARTNER_ACCOUNT && process.env.VITE_TILLED_PUBLIC_KEY && process.env.VITE_TILLED_MERCHANT_ACCOUNT_ID && process.env.VITE_TILLED_CUSTOMER_ID;
-console.log(fs.readdirSync('.'));
-// These .env files need to be created in the react-ts-checkout submodule
-// Vite needs the .env file to be in the client directory
-// and the env variables to be prefixed with VITE_
-function createEnvFiles() {
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+var fs = require('fs');
+var tilled = require('../dist');
+function createNewCustomer() {
+    var config = new tilled.Configuration({
+      apiKey: process.env.TILLED_SECRET_KEY,
+      basePath: process.env.BASE_PATH || 'https://staging-api.tilled.com',
+      baseOptions: { timeout: 2000 }
+    });
+    var customersApi = new tilled.CustomersApi(config);
+    var customerId = process.env.VITE_TILLED_CUSTOMER_ID;
+  
+    console.log('Creating a new customer');
+  
+    customersApi
+      .createCustomer({
+        tilled_account: process.env.VITE_TILLED_MERCHANT_ACCOUNT_ID,
+        CustomerCreateParams: {
+          email: 'testymctesterface@test.com',
+          first_name: 'Testy',
+          last_name: 'McTesterface'
+        }
+      })
+      .then((response) => {
+        console.log(response.data);
+        customerId = response.data.id;
+  
+        var serverEnv =
+          'BASE_PATH=https://staging-api.tilled.com\nTILLED_SECRET_KEY='
+            .concat(process.env.TILLED_SECRET_KEY, '\nTILLED_PARTNER_ACCOUNT=')
+            .concat(process.env.TILLED_PARTNER_ACCOUNT);
+        var clientEnv = 'VITE_TILLED_PUBLIC_KEY='
+          .concat(
+            process.env.VITE_TILLED_PUBLIC_KEY,
+            '\nVITE_TILLED_MERCHANT_ACCOUNT_ID='
+          )
+          .concat(
+            process.env.VITE_TILLED_MERCHANT_ACCOUNT_ID,
+            '\nVITE_TILLED_CUSTOMER_ID='
+          )
+          .concat(
+            customerId,
+            '\nVITE_TILLED_MERCHANT_NAME=SDK Test\nVITE_TILLED_MERCHANT_TAX=1'
+          );
+        var envVarsExist =
+          process.env.TILLED_SECRET_KEY &&
+          process.env.TILLED_PARTNER_ACCOUNT &&
+          process.env.VITE_TILLED_PUBLIC_KEY &&
+          process.env.VITE_TILLED_MERCHANT_ACCOUNT_ID &&
+          customerId;
+  
+        createEnvFiles(serverEnv, clientEnv, envVarsExist);
+        console.log(fs.readdirSync('.'));
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }
+  createNewCustomer();
+  
+  // These .env files need to be created in the react-ts-checkout submodule
+  // Vite needs the .env file to be in the client directory
+  // and the env variables to be prefixed with VITE_
+  function createEnvFiles(serverEnv, clientEnv, envVarsExist) {
     console.log('Creating .env files in');
     if (!fs.existsSync('./test/project/react/react-ts-checkout')) {
-        console.log(fs.readdirSync('./'));
-        throw new Error('The react-ts-checkout submodule does not exist');
-    }
-    else if (!envVarsExist) {
-        throw new Error('Environment variables are not set');
+      console.log(fs.readdirSync('./'));
+      throw new Error('The react-ts-checkout submodule does not exist');
+    } else if (!envVarsExist) {
+      throw new Error('Environment variables are not set');
     }
     fs.writeFileSync('./test/project/react/react-ts-checkout/.env', serverEnv);
-    fs.writeFileSync('./test/project/react/react-ts-checkout/client/.env', clientEnv);
+    fs.writeFileSync(
+      './test/project/react/react-ts-checkout/client/.env',
+      clientEnv
+    );
     console.log('Successfully created .env files');
-}
-createEnvFiles();
+  }
+  

--- a/test/ci-setup-env.js
+++ b/test/ci-setup-env.js
@@ -3,28 +3,33 @@ Object.defineProperty(exports, '__esModule', { value: true });
 var fs = require('fs');
 var tilled = require('../dist');
 function createNewCustomer() {
-    var config = new tilled.Configuration({
-      apiKey: process.env.TILLED_SECRET_KEY,
-      basePath: process.env.BASE_PATH || 'https://staging-api.tilled.com',
-      baseOptions: { timeout: 2000 }
-    });
-    var customersApi = new tilled.CustomersApi(config);
     var customerId = process.env.VITE_TILLED_CUSTOMER_ID;
   
     console.log('Creating a new customer');
   
-    customersApi
-      .createCustomer({
-        tilled_account: process.env.VITE_TILLED_MERCHANT_ACCOUNT_ID,
-        CustomerCreateParams: {
+    fetch(
+      `${process.env.BASE_PATH || 'https://staging-api.tilled.com'}/v1/customers`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'tilled-api-key': `${process.env.TILLED_SECRET_KEY}`,
+          'tilled-account': `${process.env.VITE_TILLED_MERCHANT_ACCOUNT_ID}`
+        },
+        body: JSON.stringify({
+          tilled_account: process.env.VITE_TILLED_MERCHANT_ACCOUNT_ID,
           email: 'testymctesterface@test.com',
           first_name: 'Testy',
           last_name: 'McTesterface'
-        }
-      })
+        })
+      }
+    )
       .then((response) => {
-        console.log(response.data);
-        customerId = response.data.id;
+          return response.json();
+      })
+      .then((data) => {
+          console.log(data);
+        var customerId = process.env.VITE_TILLED_CUSTOMER_ID || data.id;
   
         var serverEnv =
           'BASE_PATH=https://staging-api.tilled.com\nTILLED_SECRET_KEY='

--- a/test/ci-setup-env.js
+++ b/test/ci-setup-env.js
@@ -1,6 +1,7 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
 var fs = require('fs');
+console.log(fs.readdirSync('.'));
 var tilled = require('../dist');
 function createNewCustomer() {
     var config = new tilled.Configuration({

--- a/test/ci-setup-env.js
+++ b/test/ci-setup-env.js
@@ -1,10 +1,7 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
 var fs = require('fs');
-var tilled = require('../dist');
 function createNewCustomer() {
-    var customerId = process.env.VITE_TILLED_CUSTOMER_ID;
-  
     console.log('Creating a new customer');
   
     fetch(

--- a/test/ci-setup-env.js
+++ b/test/ci-setup-env.js
@@ -1,7 +1,6 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
 var fs = require('fs');
-console.log(fs.readdirSync('.'));
 var tilled = require('../dist');
 function createNewCustomer() {
     var config = new tilled.Configuration({

--- a/test/local-setup-env.js
+++ b/test/local-setup-env.js
@@ -1,25 +1,81 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-var fs = require("fs");
-var dotenv = require("dotenv");
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+var fs = require('fs');
+var tilled = require('../dist');
+var dotenv = require('dotenv');
 dotenv.config();
-var serverEnv = "BASE_PATH=https://staging-api.tilled.com\nTILLED_SECRET_KEY=".concat(process.env.TILLED_SECRET_KEY, "\nTILLED_PARTNER_ACCOUNT=").concat(process.env.TILLED_PARTNER_ACCOUNT);
-var clientEnv = "VITE_TILLED_PUBLIC_KEY=".concat(process.env.VITE_TILLED_PUBLIC_KEY, "\nVITE_TILLED_MERCHANT_ACCOUNT_ID=").concat(process.env.VITE_TILLED_MERCHANT_ACCOUNT_ID, "\nVITE_TILLED_CUSTOMER_ID=").concat(process.env.VITE_TILLED_CUSTOMER_ID, "\nVITE_TILLED_MERCHANT_NAME=SDK Test\nVITE_TILLED_MERCHANT_TAX=1");
-var envVarsExist = process.env.TILLED_SECRET_KEY && process.env.TILLED_PARTNER_ACCOUNT && process.env.VITE_TILLED_PUBLIC_KEY && process.env.VITE_TILLED_MERCHANT_ACCOUNT_ID && process.env.VITE_TILLED_CUSTOMER_ID;
+function createNewCustomer() {
+  var config = new tilled.Configuration({
+    apiKey: process.env.TILLED_SECRET_KEY,
+    basePath: process.env.BASE_PATH || 'https://staging-api.tilled.com',
+    baseOptions: { timeout: 2000 }
+  });
+  var customersApi = new tilled.CustomersApi(config);
+  var customerId = process.env.VITE_TILLED_CUSTOMER_ID;
+
+  console.log('Creating a new customer');
+
+  customersApi
+    .createCustomer({
+      tilled_account: process.env.VITE_TILLED_MERCHANT_ACCOUNT_ID,
+      CustomerCreateParams: {
+        email: 'testymctesterface@test.com',
+        first_name: 'Testy',
+        last_name: 'McTesterface'
+      }
+    })
+    .then((response) => {
+      console.log(response.data);
+      customerId = response.data.id;
+
+      var serverEnv =
+        'BASE_PATH=https://staging-api.tilled.com\nTILLED_SECRET_KEY='
+          .concat(process.env.TILLED_SECRET_KEY, '\nTILLED_PARTNER_ACCOUNT=')
+          .concat(process.env.TILLED_PARTNER_ACCOUNT);
+      var clientEnv = 'VITE_TILLED_PUBLIC_KEY='
+        .concat(
+          process.env.VITE_TILLED_PUBLIC_KEY,
+          '\nVITE_TILLED_MERCHANT_ACCOUNT_ID='
+        )
+        .concat(
+          process.env.VITE_TILLED_MERCHANT_ACCOUNT_ID,
+          '\nVITE_TILLED_CUSTOMER_ID='
+        )
+        .concat(
+          customerId,
+          '\nVITE_TILLED_MERCHANT_NAME=SDK Test\nVITE_TILLED_MERCHANT_TAX=1'
+        );
+      var envVarsExist =
+        process.env.TILLED_SECRET_KEY &&
+        process.env.TILLED_PARTNER_ACCOUNT &&
+        process.env.VITE_TILLED_PUBLIC_KEY &&
+        process.env.VITE_TILLED_MERCHANT_ACCOUNT_ID &&
+        customerId;
+
+      createEnvFiles(serverEnv, clientEnv, envVarsExist);
+      console.log(fs.readdirSync('.'));
+    })
+    .catch((error) => {
+      console.error(error);
+    });
+}
+createNewCustomer();
+
 // These .env files need to be created in the react-ts-checkout submodule
 // Vite needs the .env file to be in the client directory
 // and the env variables to be prefixed with VITE_
-function createEnvFiles() {
-    console.log('Creating .env files in');
-    if (!fs.existsSync('./test/project/react/react-ts-checkout')) {
-        console.log(fs.readdirSync('./'));
-        throw new Error('The react-ts-checkout submodule does not exist');
-    }
-    else if (!envVarsExist) {
-        throw new Error('Environment variables are not set');
-    }
-    fs.writeFileSync('./test/project/react/react-ts-checkout/.env', serverEnv);
-    fs.writeFileSync('./test/project/react/react-ts-checkout/client/.env', clientEnv);
-    console.log('Successfully created .env files');
+function createEnvFiles(serverEnv, clientEnv, envVarsExist) {
+  console.log('Creating .env files in');
+  if (!fs.existsSync('./test/project/react/react-ts-checkout')) {
+    console.log(fs.readdirSync('./'));
+    throw new Error('The react-ts-checkout submodule does not exist');
+  } else if (!envVarsExist) {
+    throw new Error('Environment variables are not set');
+  }
+  fs.writeFileSync('./test/project/react/react-ts-checkout/.env', serverEnv);
+  fs.writeFileSync(
+    './test/project/react/react-ts-checkout/client/.env',
+    clientEnv
+  );
+  console.log('Successfully created .env files');
 }
-createEnvFiles();

--- a/test/local-setup-env.js
+++ b/test/local-setup-env.js
@@ -5,28 +5,33 @@ var tilled = require('../dist');
 var dotenv = require('dotenv');
 dotenv.config();
 function createNewCustomer() {
-  var config = new tilled.Configuration({
-    apiKey: process.env.TILLED_SECRET_KEY,
-    basePath: process.env.BASE_PATH || 'https://staging-api.tilled.com',
-    baseOptions: { timeout: 2000 }
-  });
-  var customersApi = new tilled.CustomersApi(config);
   var customerId = process.env.VITE_TILLED_CUSTOMER_ID;
 
   console.log('Creating a new customer');
 
-  customersApi
-    .createCustomer({
-      tilled_account: process.env.VITE_TILLED_MERCHANT_ACCOUNT_ID,
-      CustomerCreateParams: {
+  fetch(
+    `${process.env.BASE_PATH || 'https://staging-api.tilled.com'}/v1/customers`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'tilled-api-key': `${process.env.TILLED_SECRET_KEY}`,
+        'tilled-account': `${process.env.VITE_TILLED_MERCHANT_ACCOUNT_ID}`
+      },
+      body: JSON.stringify({
+        tilled_account: process.env.VITE_TILLED_MERCHANT_ACCOUNT_ID,
         email: 'testymctesterface@test.com',
         first_name: 'Testy',
         last_name: 'McTesterface'
-      }
-    })
+      })
+    }
+  )
     .then((response) => {
-      console.log(response.data);
-      customerId = response.data.id;
+        return response.json();
+    })
+    .then((data) => {
+        console.log(data);
+      var customerId = process.env.VITE_TILLED_CUSTOMER_ID || data.id;
 
       var serverEnv =
         'BASE_PATH=https://staging-api.tilled.com\nTILLED_SECRET_KEY='

--- a/test/local-setup-env.js
+++ b/test/local-setup-env.js
@@ -1,12 +1,9 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
 var fs = require('fs');
-var tilled = require('../dist');
 var dotenv = require('dotenv');
 dotenv.config();
 function createNewCustomer() {
-  var customerId = process.env.VITE_TILLED_CUSTOMER_ID;
-
   console.log('Creating a new customer');
 
   fetch(

--- a/test/local-setup-env.js
+++ b/test/local-setup-env.js
@@ -28,7 +28,7 @@ function createNewCustomer() {
     })
     .then((data) => {
         console.log(data);
-      var customerId = process.env.VITE_TILLED_CUSTOMER_ID || data.id;
+      var customerId = data.id || process.env.VITE_TILLED_CUSTOMER_ID;
 
       var serverEnv =
         'BASE_PATH=https://staging-api.tilled.com\nTILLED_SECRET_KEY='

--- a/test/make-payment.spec.ts
+++ b/test/make-payment.spec.ts
@@ -83,6 +83,7 @@ test('create and confirm a payment intent with a new card payment method', async
         'creating new pm card {name: Testy McTesterson, address: Object}',
         'new pm {ach_debit: null, billing_details: Object, card_present: null, chargeable: true, created_at:',
         'attaching pm to customer {ach_debit: null, billing_details: Object, card_present: null, chargeable: true, created_at:',
+        'using saved pm {ach_debit: null, billing_details: Object, card_present: null, chargeable: true, created_at:'
       ],
       DelimiterEnum.wildcards
     )

--- a/test/make-payment.spec.ts
+++ b/test/make-payment.spec.ts
@@ -83,7 +83,6 @@ test('create and confirm a payment intent with a new card payment method', async
         'creating new pm card {name: Testy McTesterson, address: Object}',
         'new pm {ach_debit: null, billing_details: Object, card_present: null, chargeable: true, created_at:',
         'attaching pm to customer {ach_debit: null, billing_details: Object, card_present: null, chargeable: true, created_at:',
-        'using saved pm {ach_debit: null, billing_details: Object, card_present: null, chargeable: true, created_at:'
       ],
       DelimiterEnum.wildcards
     )

--- a/test/make-payment.spec.ts
+++ b/test/make-payment.spec.ts
@@ -82,8 +82,8 @@ test('create and confirm a payment intent with a new card payment method', async
       [
         'creating new pm card {name: Testy McTesterson, address: Object}',
         'new pm {ach_debit: null, billing_details: Object, card_present: null, chargeable: true, created_at:',
-        'attaching pm to customer {ach_debit: null, billing_details: Object, card_present: null, chargeable: true, created_at:'
-        // 'using saved pm {ach_debit: null, billing_details: Object, card_present: null, chargeable: true, created_at:'
+        'attaching pm to customer {ach_debit: null, billing_details: Object, card_present: null, chargeable: true, created_at:',
+        'using saved pm {ach_debit: null, billing_details: Object, card_present: null, chargeable: true, created_at:'
       ],
       DelimiterEnum.wildcards
     )
@@ -109,7 +109,7 @@ test('confirm a payment intent with a saved card payment method', async ({
   // expect payment method select to be visible and select the saved card payment method
   await expect(page.getByTestId('payment-form-container')).toBeVisible();
   await page.getByTestId('payment-method-select').click();
-  await page.getByTestId('pm-option-visa-1111').first().click(); // this element is dynamically generated. It's not in the initial HTML
+  await page.getByTestId('pm-option-visa-1111').click(); // this element is dynamically generated. It's not in the initial HTML
 
   // submit the payment form
   page.getByTestId('submit-button').click();


### PR DESCRIPTION
This pull request introduces significant changes to the environment setup scripts by adding functionality to create a new customer using the Tilled API. The changes include the addition of a new function to handle customer creation and updates to the way environment variables are managed.

### Enhancements to environment setup scripts:

* [`test/ci-setup-env.js`](diffhunk://#diff-12a2c2ad04c19e24e2464075a9d8f320b70bc5b26dcfb7a2f7f69ae21585e4e7L1-R80): Added a new function `createNewCustomer` to create a new customer using the Tilled API, and updated the environment variable handling to include the newly created customer ID.
* [`test/local-setup-env.js`](diffhunk://#diff-8ffc9a7a101a698c32fe783dffbd45b72fd602297d76feff9e376e779f54dbaeL1-L25): Similar to the changes in `ci-setup-env.js`, added the `createNewCustomer` function and updated the handling of environment variables.