### PR TITLE
chore: update pull-request in action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Create Pull Request
         id: create_pr
         if: ${{ steps.push-temp.outcome == 'success'}}
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v7
         with:
           branch: temp-branch
           delete-branch: true


### PR DESCRIPTION
Updates peter-evans/create-pull-request to v7 because old version uses a deprecated version of `actions/upload-artifact: v3`, resulting in [failing runs](https://github.com/gettilled/tilled-node/actions/runs/13134973613/job/36648250416)